### PR TITLE
Fix build with GHC 9.2

### DIFF
--- a/Data/PrimitiveArray/Dense.hs
+++ b/Data/PrimitiveArray/Dense.hs
@@ -79,7 +79,7 @@ instance (NFData (LimitType sh), NFData (v e)) ⇒ NFData (Dense v sh e) where
 
 
 
-data instance MutArr m (Dense v sh e) = MDense !(LimitType sh) !(VG.Mutable v (PrimState m) e)
+data instance MutArr m (Dense (v :: * -> *) sh e) = MDense !(LimitType sh) !(VG.Mutable v (PrimState m) e)
   deriving (Generic,Typeable)
 
 instance (Show (LimitType sh), Show (VG.Mutable v (PrimState m) e), VG.Mutable v (PrimState m) e ~ mv) ⇒ Show (MutArr m (Dense v sh e)) where

--- a/Data/PrimitiveArray/Sparse/BinSearch.hs
+++ b/Data/PrimitiveArray/Sparse/BinSearch.hs
@@ -63,7 +63,7 @@ type Boxed    w sh e = Sparse w  V.Vector sh e
 -- | Currently, our mutable variant of sparse matrices will keep indices and manhattan starts
 -- immutable as well.
 
-data instance MutArr m (Sparse w v sh e) = MSparse
+data instance MutArr m (Sparse w (v :: * -> *) sh e) = MSparse
   { msparseUpperBound :: !(LimitType sh)
   , msparseData       :: !(VG.Mutable v (PrimState m) e)
   , msparseIndices    :: !(w sh) -- (VG.Mutable w (PrimState m) sh)

--- a/Data/PrimitiveArray/Sparse/IntBinSearch.hs
+++ b/Data/PrimitiveArray/Sparse/IntBinSearch.hs
@@ -64,7 +64,7 @@ type Boxed    w sh e = Sparse w  V.Vector sh e
 -- | Currently, our mutable variant of sparse matrices will keep indices and manhattan starts
 -- immutable as well.
 
-data instance MutArr m (Sparse w v sh e) = MSparse
+data instance MutArr m (Sparse w (v :: * -> *) sh e) = MSparse
   { msparseUpperBound :: !(LimitType sh)
   , msparseData       :: !(VG.Mutable v (PrimState m) e)
   , msparseIndices    :: !(VU.Vector Int)


### PR DESCRIPTION
Background:
https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#kind-inference-for-data-family-instances-is-pickier

Fixes #1.